### PR TITLE
Fix static initialization order bug crashing the app on load

### DIFF
--- a/name-on-cli-tests/CliTests.cs
+++ b/name-on-cli-tests/CliTests.cs
@@ -234,7 +234,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("adj-noun-num");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Adjective, ElementType.Noun, ElementType.ThreeDigit },
+                new[] { ElementType.Adjective, ElementType.Noun, ElementType.Number },
                 result);
         }
 
@@ -252,7 +252,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("noun-num");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Noun, ElementType.ThreeDigit },
+                new[] { ElementType.Noun, ElementType.Number },
                 result);
         }
 
@@ -261,7 +261,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("noun-adj-num");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Noun, ElementType.Adjective, ElementType.ThreeDigit },
+                new[] { ElementType.Noun, ElementType.Adjective, ElementType.Number },
                 result);
         }
 
@@ -277,7 +277,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("adjective-noun-number");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Adjective, ElementType.Noun, ElementType.ThreeDigit },
+                new[] { ElementType.Adjective, ElementType.Noun, ElementType.Number },
                 result);
         }
 
@@ -286,7 +286,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("noun-noun-num");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Noun, ElementType.Noun, ElementType.ThreeDigit },
+                new[] { ElementType.Noun, ElementType.Noun, ElementType.Number },
                 result);
         }
 
@@ -302,7 +302,7 @@ namespace name_on_cli_tests
         {
             var result = FormatParser.Parse("ADJ-Noun-NUM");
             CollectionAssert.AreEqual(
-                new[] { ElementType.Adjective, ElementType.Noun, ElementType.ThreeDigit },
+                new[] { ElementType.Adjective, ElementType.Noun, ElementType.Number },
                 result);
         }
     }

--- a/name-on-cli/Program.cs
+++ b/name-on-cli/Program.cs
@@ -106,7 +106,7 @@ namespace name_on_cli
             {
                 "adj" or "adjective" => ElementType.Adjective,
                 "noun" => ElementType.Noun,
-                "num" or "number" => ElementType.ThreeDigit,
+                "num" or "number" => ElementType.Number,
                 _ => throw new ArgumentException($"Unknown format part: '{part}'. Use: adj, noun, num")
             };
         }

--- a/name-on-core/FormatTemplate.cs
+++ b/name-on-core/FormatTemplate.cs
@@ -17,12 +17,12 @@ namespace name_on_core
             Elements = elements;
         }
 
-        public static FormatTemplate Default { get; } = AdjectiveNounNumber;
-
         public static FormatTemplate AdjectiveNounNumber { get; } = new FormatTemplate(
             "adjective-noun-number",
             "Adjective-Noun-Number",
             new[] { ElementType.Adjective, ElementType.Noun, ElementType.Number });
+
+        public static FormatTemplate Default { get; } = AdjectiveNounNumber;
 
         public static FormatTemplate AdjectiveNoun { get; } = new FormatTemplate(
             "adjective-noun",


### PR DESCRIPTION
## Summary
- **Fixed production crash**: `FormatTemplate.Default` was declared before `AdjectiveNounNumber` in the source file, so C# initialized it to `null` (static fields initialize in declaration order). This caused a `NullReferenceException` in the `NameOn` component constructor, preventing the app from rendering at all.
- **Fixed stale enum references**: Updated `ElementType.ThreeDigit` → `ElementType.Number` in the CLI and CLI tests (the enum was renamed during the customization feature but these references were missed).

## Test plan
- [x] `dotnet build` succeeds with 0 errors, 0 warnings
- [x] `dotnet test` passes all 75 tests (39 unit + 36 CLI)
- [x] Verified locally that the Blazor app loads, generates names, and the options panel works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)