### PR TITLE
Add word mnemonic generator feature

### DIFF
--- a/name-on-blazor/NameOn.razor
+++ b/name-on-blazor/NameOn.razor
@@ -27,6 +27,39 @@
     </button>
 
     <div class="mt-3">
+        @if (_mnemonicLoading)
+        {
+            <div class="spinner-border spinner-border-sm text-secondary" role="status">
+                <span class="sr-only">Generating mnemonic...</span>
+            </div>
+        }
+        else if (_mnemonic != null)
+        {
+            <div class="card mt-2 mx-auto" style="max-width: 500px;">
+                <div class="card-body py-2 px-3 text-left">
+                    <small class="text-muted">Mnemonic</small>
+                    <p class="mb-1">@_mnemonic</p>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="CopyMnemonicToClipboard">
+                        Copy mnemonic
+                    </button>
+                </div>
+            </div>
+        }
+        else if (_mnemonicError != null)
+        {
+            <div class="alert alert-warning small py-1 px-2 mt-2 mx-auto" style="max-width: 500px;">
+                @_mnemonicError
+            </div>
+        }
+        else if (!IsLoading)
+        {
+            <button class="btn btn-outline-secondary btn-sm" @onclick="GenerateMnemonic">
+                Generate mnemonic
+            </button>
+        }
+    </div>
+
+    <div class="mt-3">
         <button class="btn btn-outline-secondary btn-sm" @onclick="ToggleCustomization">
             @(_showCustomization ? "Hide" : "Show") Options
         </button>
@@ -125,8 +158,12 @@
 @code {
     private Namer _namer = new();
     private string CurrentName = string.Empty;
+    private string[] _currentParts = Array.Empty<string>();
     private bool IsLoading = true;
     private bool _showCustomization = false;
+    private string _mnemonic = null;
+    private bool _mnemonicLoading = false;
+    private string _mnemonicError = null;
     private string _selectedTemplateId = FormatTemplate.Default.Id;
     private JoiningStyle _selectedJoiningStyle = JoiningStyle.Dash;
     private int _selectedMaxValue = 999;
@@ -266,9 +303,33 @@
     private void GenerateName()
     {
         IsLoading = true;
+        _mnemonic = null;
+        _mnemonicError = null;
         StateHasChanged();
-        CurrentName = _namer.Gen(_options);
+        var result = _namer.GenWithParts(_options);
+        CurrentName = result.name;
+        _currentParts = result.parts;
         IsLoading = false;
+    }
+
+    private async Task GenerateMnemonic()
+    {
+        _mnemonicLoading = true;
+        _mnemonicError = null;
+        _mnemonic = null;
+        StateHasChanged();
+        try
+        {
+            _mnemonic = await JS.InvokeAsync<string>("generateMnemonic", new object[] { _currentParts });
+        }
+        catch (Exception ex)
+        {
+            _mnemonicError = $"Could not generate mnemonic: {ex.Message}";
+        }
+        finally
+        {
+            _mnemonicLoading = false;
+        }
     }
 
     private async Task CopyToClipboard()
@@ -277,6 +338,12 @@
         {
             await JS.InvokeVoidAsync("navigator.clipboard.writeText", CurrentName);
         }
+    }
+
+    private async Task CopyMnemonicToClipboard()
+    {
+        if (!string.IsNullOrEmpty(_mnemonic))
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _mnemonic);
     }
 
     private async Task SavePreferences()

--- a/name-on-blazor/wwwroot/index.html
+++ b/name-on-blazor/wwwroot/index.html
@@ -59,5 +59,20 @@
         </div>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="https://js.puter.com/v2/"></script>
+    <script>
+        window.generateMnemonic = async function (words) {
+            const prompt = `Create a short, memorable 1-2 sentence story using all of these words: ${words.join(', ')}. The story should be whimsical and easy to remember. Return only the story itself, nothing else.`;
+            const response = await puter.ai.chat(prompt);
+            // Normalize response across Puter's supported model formats
+            if (typeof response === 'string') return response;
+            if (response?.message?.content) {
+                const c = response.message.content;
+                if (typeof c === 'string') return c;
+                if (Array.isArray(c)) return c.map(x => x.text ?? x).join('');
+            }
+            return String(response);
+        };
+    </script>
 </body>
 </html>

--- a/name-on-core/Namer.cs
+++ b/name-on-core/Namer.cs
@@ -56,6 +56,23 @@ namespace name_on_core
             return _lastReturn;
         }
 
+        public (string name, string[] parts) GenWithParts(NameOptions options)
+        {
+            var filteredAdjectives = options.WordFilter.Filter(Adjectives);
+            var filteredNouns = options.WordFilter.Filter(Nouns);
+
+            var parts = GenerateParts(options, filteredAdjectives, filteredNouns);
+            var retVal = JoiningStyleHelper.Join(options.JoiningStyle, parts);
+
+            while (_lastReturn == retVal)
+            {
+                parts = GenerateParts(options, filteredAdjectives, filteredNouns);
+                retVal = JoiningStyleHelper.Join(options.JoiningStyle, parts);
+            }
+            _lastReturn = retVal;
+            return (retVal, parts);
+        }
+
         private string[] GenerateParts(NameOptions options, List<string> adjectives, List<string> nouns)
         {
             return options.Template.Elements.Select(et => et switch


### PR DESCRIPTION
Adds a "Generate mnemonic" button to the Blazor UI that calls Puter.js
(free, no API key required) to create a short story using the generated
name's words. The mnemonic is on-demand (not auto-generated) to avoid
unnecessary API calls. Generating a new name resets the mnemonic state.

- name-on-core: add Namer.GenWithParts() to expose word parts alongside
  the joined name, so the prompt receives natural-language words regardless
  of joining style (dash, camelCase, etc.)
- index.html: load Puter.js CDN and expose window.generateMnemonic() JS
  interop helper that normalises the response across Puter's model formats
- NameOn.razor: add mnemonic state fields, wire GenerateName() to
  GenWithParts(), add GenerateMnemonic() async handler and CopyMnemonicToClipboard(),
  and render the button/spinner/card/error UI block

https://claude.ai/code/session_01CHpW2uBgsxJKG1shFbWuz6